### PR TITLE
fix: use jekyll built in for updating copyright year

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -34,7 +34,7 @@
     // uncomment footer when we got the goods -->
 
     <p class="p-0">{% include icon-twitter.html username=site.twitter_username %} - <a href="/credits" class="c-red">credits</a></p>
-    <p class="c-l.8 p-0">&copy; 2016 Jeremy Ricketts &amp; Michael Chan</p>
+    <p class="c-l.8 p-0">&copy; {{ site.time | date: '%Y' }} Jeremy Ricketts &amp; Michael Chan</p>
 
   </div>
 


### PR DESCRIPTION
A handy filter for getting the year updated with each build.